### PR TITLE
fix: `connect` reject error type

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ function App() {
       .reject((error) => {
         // You MUST handle the reject because once the user closes the modal, peraWallet.connect() promise will be rejected.
         // For the async/await syntax you MUST use try/catch
+        if (error?.data?.type !== "CONNECT_MODAL_CLOSED") {
+          // log the necessary errors
+        }
       });
   }
 

--- a/src/modal/peraWalletConnectModalUtils.tsx
+++ b/src/modal/peraWalletConnectModalUtils.tsx
@@ -54,9 +54,9 @@ function openPeraWalletConnectModal(rejectPromise?: (error: any) => void) {
         rejectPromise(
           new PeraWalletConnectError(
             {
-              type: "SESSION_CONNECT"
+              type: "CONNECT_MODAL_CLOSED"
             },
-            "The action canceled by the user."
+            "The modal has been closed by the user."
           )
         );
       }

--- a/src/util/PeraWalletConnectError.ts
+++ b/src/util/PeraWalletConnectError.ts
@@ -4,7 +4,8 @@ interface PeraWalletConnectErrorData {
     | "SESSION_DISCONNECT"
     | "SESSION_UPDATE"
     | "SESSION_CONNECT"
-    | "SESSION_RECONNECT";
+    | "SESSION_RECONNECT"
+    | "CONNECT_MODAL_CLOSED";
   detail?: any;
 }
 


### PR DESCRIPTION
The reject scenario for the `peraWallet.connect` now can be caught with `CONNECT_MODAL_CLOSED` error type. 
