### PR TITLE
feat: Export a function to close the sign toast

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,21 @@ function App() {
 
 `@perawallet/connect` also allows signing transactions using the Pera Wallet application. Once the `signTransaction` method is triggered if the user is on a mobile browser, the Pera Wallet app will be launched automatically, if the browser blocks the redirection there's also a popup that links to the Pera Wallet app.
 
-`@perawallet/connect` guides users with a toast message when the `signTransaction` is triggered. It's enabled by default but in some cases, you may not need to the toast message (e.g. you already have signing guidance for users). There's a configuration called `shouldShowSignTxnToast` to disable it, see the example below:
+`@perawallet/connect` guides users with a toast message when the `signTransaction` is triggered on desktop. It's enabled by default but in some cases, you may not need to the toast message (e.g. you already have signing guidance for users). There's an option called `shouldShowSignTxnToast` to disable it, see the example below:
 
 ```js
 const peraWallet = new PeraWalletConnect({shouldShowSignTxnToast: false});
+```
+
+You can also call the `closePeraWalletSignTxnToast` function to hide the toast.
+
+```js
+import {closePeraWalletSignTxnToast} from "@perawallet/connect";
+
+// ...Business logic
+
+// Close the toast message
+closePeraWalletSignTxnToast();
 ```
 
 `signTransaction` accepts `SignerTransaction[][]` the type can be found [here](./src/util/model/peraWalletModels.ts)

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,7 @@ window.Buffer = window.Buffer || require("buffer").Buffer;
 
 // Components
 import PeraWalletConnect from "./PeraWalletConnect";
+// Utilities
+import {closePeraWalletSignTxnToast} from "./modal/peraWalletConnectModalUtils";
 
-export {PeraWalletConnect};
+export {PeraWalletConnect, closePeraWalletSignTxnToast};

--- a/src/modal/peraWalletConnectModalUtils.tsx
+++ b/src/modal/peraWalletConnectModalUtils.tsx
@@ -5,10 +5,10 @@ import React from "react";
 import ReactDOM from "react-dom";
 import {QRCode} from "react-qrcode-logo";
 
-import PeraWalletConnectModal from "./PeraWalletConnectModal";
-import PeraWalletRedirectModal from "./redirect/PeraWalletRedirectModal";
 import {AccordionData} from "./component/accordion/util/accordionTypes";
 import PeraWalletConnectError from "../util/PeraWalletConnectError";
+import PeraWalletConnectModal from "./PeraWalletConnectModal";
+import PeraWalletRedirectModal from "./redirect/PeraWalletRedirectModal";
 import PeraWalletSignTxnToast from "./sign-toast/PeraWalletSignTxnToast";
 
 // The ID of the wrapper element for PeraWalletConnectModal
@@ -18,7 +18,7 @@ const PERA_WALLET_CONNECT_MODAL_ID = "pera-wallet-connect-modal-wrapper";
 const PERA_WALLET_REDIRECT_MODAL_ID = "pera-wallet-redirect-modal-wrapper";
 
 // The ID of the wrapper element for PeraWalletSignTxnToast
-const PERA_WALLET_SIGN_TXN_TOAST_ID = "pera-wallet-sign-txn-toast";
+const PERA_WALLET_SIGN_TXN_TOAST_ID = "pera-wallet-sign-txn-toast-wrapper";
 
 /**
  * @returns {HTMLDivElement} wrapper element for PeraWalletConnectModal
@@ -95,13 +95,13 @@ function openPeraWalletSignTxnToast() {
   const wrapper = createModalWrapperOnDOM(PERA_WALLET_SIGN_TXN_TOAST_ID);
 
   ReactDOM.render(
-    <PeraWalletSignTxnToast onClose={handlePeraWalletSignTxnToast} />,
+    <PeraWalletSignTxnToast onClose={closePeraWalletSignTxnToast} />,
     wrapper
   );
+}
 
-  function handlePeraWalletSignTxnToast() {
-    removeModalWrapperFromDOM(PERA_WALLET_SIGN_TXN_TOAST_ID);
-  }
+function closePeraWalletSignTxnToast() {
+  removeModalWrapperFromDOM(PERA_WALLET_SIGN_TXN_TOAST_ID);
 }
 
 /**
@@ -176,5 +176,6 @@ export {
   openPeraWalletConnectModal,
   openPeraWalletRedirectModal,
   openPeraWalletSignTxnToast,
+  closePeraWalletSignTxnToast,
   removeModalWrapperFromDOM
 };

--- a/src/modal/sign-toast/_pera-wallet-sign-txn-toast.scss
+++ b/src/modal/sign-toast/_pera-wallet-sign-txn-toast.scss
@@ -5,7 +5,7 @@
   --pera-wallet-sign-txn-toast-height: 134px;
   --pera-wallet-sign-txn-toast-font-family: "Inter", sans-serif;
 
-  position: absolute;
+  position: fixed;
   bottom: 28px;
   right: 35px;
   z-index: 11;


### PR DESCRIPTION
Added a function to be able to close the Sign TXN Toast outside from the library: `closePeraWalletSignTxnToast`
