### PR TITLE
fix(sign-txn): Solve ios app launch issue

### DIFF
--- a/src/PeraWalletConnect.ts
+++ b/src/PeraWalletConnect.ts
@@ -25,8 +25,10 @@ import {
 } from "./util/transaction/transactionUtils";
 import {isMobile} from "./util/device/deviceUtils";
 import {AppMeta} from "./util/peraWalletTypes";
-import {getPeraWalletAppMeta} from "./util/peraWalletUtils";
-import {PERA_WALLET_APP_DEEP_LINK} from "./util/peraWalletConstants";
+import {
+  generatePeraWalletAppDeepLink,
+  getPeraWalletAppMeta
+} from "./util/peraWalletUtils";
 
 interface PeraWalletConnectOptions {
   bridge?: string;
@@ -192,7 +194,7 @@ class PeraWalletConnect {
 
       try {
         // This is to automatically open the wallet app when trying to sign with it.
-        peraWalletAppDeeplink = window.open(PERA_WALLET_APP_DEEP_LINK, "_blank");
+        peraWalletAppDeeplink = window.open(generatePeraWalletAppDeepLink(), "_blank");
       } catch (error) {
         console.log(error);
       } finally {

--- a/src/PeraWalletConnect.ts
+++ b/src/PeraWalletConnect.ts
@@ -188,15 +188,15 @@ class PeraWalletConnect {
     }
 
     if (isMobile()) {
-      let windowObj;
+      let peraWalletAppDeeplink;
 
       try {
         // This is to automatically open the wallet app when trying to sign with it.
-        windowObj = window.open(PERA_WALLET_APP_DEEP_LINK, "_blank");
+        peraWalletAppDeeplink = window.open(PERA_WALLET_APP_DEEP_LINK, "_blank");
       } catch (error) {
         console.log(error);
       } finally {
-        if (!windowObj) {
+        if (!peraWalletAppDeeplink) {
           openPeraWalletRedirectModal();
         }
       }

--- a/src/modal/redirect/PeraWalletRedirectModal.tsx
+++ b/src/modal/redirect/PeraWalletRedirectModal.tsx
@@ -3,7 +3,7 @@ import PeraRedirectIcon from "../../asset/icon/PeraRedirectIcon.svg";
 import "../_pera-wallet-modal.scss";
 import "./_pera-wallet-redirect-modal.scss";
 
-import React, {useEffect} from "react";
+import React from "react";
 
 import {
   generatePeraWalletAppDeepLink,
@@ -19,16 +19,6 @@ function PeraWalletRedirectModal({onClose}: PeraWalletRedirectModalProps) {
   const {name, main_color} = getPeraWalletAppMeta();
 
   useSetDynamicVhValue();
-
-  useEffect(() => {
-    const peraWalletDeepLink = window.open(generatePeraWalletAppDeepLink());
-
-    if (peraWalletDeepLink) {
-      peraWalletDeepLink.addEventListener("load", onClose);
-    }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return (
     <div

--- a/src/modal/redirect/PeraWalletRedirectModal.tsx
+++ b/src/modal/redirect/PeraWalletRedirectModal.tsx
@@ -30,11 +30,13 @@ function PeraWalletRedirectModal({onClose}: PeraWalletRedirectModalProps) {
             <img src={PeraRedirectIcon} />
 
             <h1 className={"pera-wallet-redirect-modal__content__title"}>
-              {"Can't Launch Pera"}
+              {"Continue on Pera"}
             </h1>
 
             <p className={"pera-wallet-redirect-modal__content__description"}>
-              {"We couldn't redirect you to Pera Wallet automatically. Please try again."}
+              {
+                "Launch Pera Wallet to securely connect your account and sign transactions."
+              }
             </p>
 
             <p className={"pera-wallet-redirect-modal__content__install-pera-text"}>


### PR DESCRIPTION
### Description
- On your first interaction (sign act) with the dApp browser asks you to "allow popups", if you allow it then it's all good if you don't allow it we'll show the redirect popup.
- There are some cases where Pera Wallet launches successfully but the redirect popup also shows up. 
- In some cases, safari can not ask permisson or redirect user to app. 

### Fixes
- We try to redirect users to app when they try to sign txn. In mobile safari, browser ask permission in every redirection try. But in other browsers, we successfully redirect user to mobile app. Check out the videos below. If we successfully redirect user to app, we will not show redirect modal. Other than that, we will show redirect modal (For example in safari).

  - Safari ->  https://user-images.githubusercontent.com/54077855/179740481-a0b0e610-3104-46f1-81f2-c1956f2f6db8.MP4
  - Other Browsers(Opera) -> https://user-images.githubusercontent.com/54077855/179728471-c8076ea9-a71f-4fe3-85d2-3f22a1473868.MP4
  
- We solved the 3rd problem by changing the position of a condition







