### PR TITLE
fix(disconnect): `reject` with correct error type

### DIFF
--- a/src/PeraWalletConnect.ts
+++ b/src/PeraWalletConnect.ts
@@ -716,7 +716,15 @@ class PeraWalletConnect {
 
             resetWalletDetailsFromStorage();
 
-            reject(event.data.message.error);
+            reject(
+              new PeraWalletConnectError(
+                {
+                  type: "SESSION_DISCONNECTED",
+                  detail: event.data.message.error
+                },
+                event.data.message.error
+              )
+            );
           }
 
           if (event.data.message.type === "SIGN_TXN_CALLBACK_ERROR") {

--- a/src/util/PeraWalletConnectError.ts
+++ b/src/util/PeraWalletConnectError.ts
@@ -1,7 +1,7 @@
 interface PeraWalletConnectErrorData {
   type:
     | "SIGN_TRANSACTIONS"
-    | "SESSION_DISCONNECT"
+    | "SESSION_DISCONNECTED"
     | "SESSION_UPDATE"
     | "SESSION_CONNECT"
     | "SESSION_RECONNECT"


### PR DESCRIPTION
We were not rejecting the disconnect case with a correct error, so it was impossible to catch it and act accordingly.