### PR TITLE
feat: Accept `network` on `connect`

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,17 @@ It's enabled by default but in some cases, you may not need the toast message (e
 
 #### `PeraWalletConnect.connect(): Promise<string[]>`
 
+| option    | default   | value                       |          |
+| --------- | --------- | --------------------------- | -------- |
+| `network` | `mainnet` | `dev`, `testnet`, `mainnet` | optional |
+
 Starts the initial connection flow and returns the array of account addresses.
+
+`network` param of the `connect` method overrides the initial `network` on the constructor.
+
+```javascript
+PeraWalletConnect.connect({network: "testnet"}); //optional
+```
 
 #### `PeraWalletConnect.reconnectSession(): Promise<string[]>`
 

--- a/src/PeraWalletConnect.ts
+++ b/src/PeraWalletConnect.ts
@@ -361,7 +361,7 @@ class PeraWalletConnect {
     };
   }
 
-  connect() {
+  connect({network}: {network?: PeraWalletNetwork} = {}) {
     return new Promise<string[]>(async (resolve, reject) => {
       try {
         // check if already connected and kill session first before creating a new one.
@@ -370,13 +370,18 @@ class PeraWalletConnect {
           await this.connector.killSession();
         }
 
+        if (network) {
+          // override network if provided
+          getLocalStorage()?.setItem(PERA_WALLET_LOCAL_STORAGE_KEYS.NETWORK, network);
+        }
+
         const {
           isWebWalletAvailable,
           bridgeURL,
           webWalletURL,
           shouldDisplayNewBadge,
           shouldUseSound
-        } = await getPeraConnectConfig(this.network);
+        } = await getPeraConnectConfig(network || this.network);
 
         const {onWebWalletConnect} = this.connectWithWebWallet(
           resolve,


### PR DESCRIPTION
dApps can have a dynamic `network` selection to avoid page refresh requirements (the only way to update the network is to refresh the page because once you create the instance, you cannot update it). I've added a mechanism to accept `network` on the `connect` method; with this, they won't need to keep logic on their side. 