### PR TITLE
feat: Use unique storage id

### DIFF
--- a/src/PeraWalletConnect.ts
+++ b/src/PeraWalletConnect.ts
@@ -398,6 +398,7 @@ class PeraWalletConnect {
         // Create Connector instance
         this.connector = new WalletConnect({
           bridge: this.bridge || bridgeURL || "https://bridge.walletconnect.org",
+          storageId: PERA_WALLET_LOCAL_STORAGE_KEYS.WALLETCONNECT,
           qrcodeModal: generatePeraWalletConnectModalActions({
             isWebWalletAvailable,
             shouldDisplayNewBadge,
@@ -498,7 +499,8 @@ class PeraWalletConnect {
 
         if (this.bridge) {
           this.connector = new WalletConnect({
-            bridge: this.bridge
+            bridge: this.bridge,
+            storageId: PERA_WALLET_LOCAL_STORAGE_KEYS.WALLETCONNECT
           });
 
           resolve(this.connector?.accounts || []);

--- a/src/util/storage/storageConstants.ts
+++ b/src/util/storage/storageConstants.ts
@@ -1,6 +1,6 @@
 const PERA_WALLET_LOCAL_STORAGE_KEYS = {
   WALLET: "PeraWallet.Wallet",
-  WALLETCONNECT: "walletconnect",
+  WALLETCONNECT: "PeraWallet.Walletconnect",
   DEEP_LINK: "PeraWallet.DeepLink",
   APP_META: "PeraWallet.AppMeta",
   NETWORK: "PeraWallet.Network"


### PR DESCRIPTION
In [@txnlab/use-wallet](https://github.com/TxnLab/use-wallet), we allow multiple providers to be connected at the same time. 

However, with providers based on `WalletConnect`, this isn't possible because they all use the default `walletconnect` key in browser storage to store metadata. This causes conflicts when multiple `WalletConnect` providers are connected (e.g., Pera, Defly, or a generic WalletConnect session). 

Passing in a unique `storageId` key to the `WalletConnect` constructor resolves this conflict.