### PR TITLE
fix(iframe): allow hid and bluetooth allowance in iframe for ledgers

### DIFF
--- a/src/PeraWalletConnect.ts
+++ b/src/PeraWalletConnect.ts
@@ -613,13 +613,14 @@ class PeraWalletConnect {
             const peraWalletSignTxnModalIFrameWrapper = modal;
 
             const peraWalletIframe = document.createElement("iframe");
+            const peraWalletIframeSrc = generateEmbeddedWalletURL(
+              webWalletURLs.TRANSACTION_SIGN
+            );
+            const peraWalletIframeAllow = `hid ${peraWalletIframeSrc}; bluetooth ${peraWalletIframeSrc}`;
 
             peraWalletIframe.setAttribute("id", PERA_WALLET_IFRAME_ID);
-            peraWalletIframe.setAttribute(
-              "src",
-              generateEmbeddedWalletURL(webWalletURLs.TRANSACTION_SIGN)
-            );
-            peraWalletIframe.setAttribute("allow", "hid *; bluetooth *");
+            peraWalletIframe.setAttribute("src", peraWalletIframeSrc);
+            peraWalletIframe.setAttribute("allow", peraWalletIframeAllow);
 
             peraWalletSignTxnModalIFrameWrapper?.appendChild(peraWalletIframe);
 

--- a/src/PeraWalletConnect.ts
+++ b/src/PeraWalletConnect.ts
@@ -619,6 +619,7 @@ class PeraWalletConnect {
               "src",
               generateEmbeddedWalletURL(webWalletURLs.TRANSACTION_SIGN)
             );
+            peraWalletIframe.setAttribute("allow", "hid *; bluetooth *");
 
             peraWalletSignTxnModalIFrameWrapper?.appendChild(peraWalletIframe);
 


### PR DESCRIPTION
I don't know if we should allow all domains to allow hid and ble devices ot not.

I tried using regex such as `*.perawallet.app` but it doesn't work in that way.

We can fully write the if we want to restrict these allowances in iframe like:

`https://web.perawallet.app/transaction/sign?embedded=true`

cc: @mucahit and @yigiterdev
