### PR TITLE
fix: wallet connect socket transport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@perawallet/connect",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@perawallet/connect",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "ISC",
       "dependencies": {
         "@evanhahn/lottie-web-light": "5.8.1",
         "@walletconnect/client": "^1.8.0",
+        "@walletconnect/socket-transport": "github:awesome-algorand/walletconnect-socket-transport",
         "@walletconnect/types": "^1.8.0",
         "bowser": "2.11.0",
         "buffer": "^6.0.3",
@@ -804,8 +805,8 @@
     },
     "node_modules/@walletconnect/socket-transport": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.8.0.tgz",
-      "integrity": "sha512-5DyIyWrzHXTcVp0Vd93zJ5XMW61iDM6bcWT4p8DTRfFsOtW46JquruMhxOLeCOieM4D73kcr3U7WtyR4JUsGuQ==",
+      "resolved": "git+ssh://git@github.com/awesome-algorand/walletconnect-socket-transport.git#80771929f03de19a9209bbf3d554f1f94e4490e3",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/types": "^1.8.0",
         "@walletconnect/utils": "^1.8.0",
@@ -8266,9 +8267,8 @@
       "integrity": "sha512-QJzp/S/86sUAgWY6eh5MKYmSfZaRpIlmCJdi5uG4DJlKkZrHEF7ye7gA+VtbVzvTtpM/gRwO2plQuiooIeXjfg=="
     },
     "@walletconnect/socket-transport": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.8.0.tgz",
-      "integrity": "sha512-5DyIyWrzHXTcVp0Vd93zJ5XMW61iDM6bcWT4p8DTRfFsOtW46JquruMhxOLeCOieM4D73kcr3U7WtyR4JUsGuQ==",
+      "version": "git+ssh://git@github.com/awesome-algorand/walletconnect-socket-transport.git#80771929f03de19a9209bbf3d554f1f94e4490e3",
+      "from": "@walletconnect/socket-transport@github:awesome-algorand/walletconnect-socket-transport",
       "requires": {
         "@walletconnect/types": "^1.8.0",
         "@walletconnect/utils": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@evanhahn/lottie-web-light": "5.8.1",
     "@walletconnect/client": "^1.8.0",
+    "@walletconnect/socket-transport": "github:awesome-algorand/walletconnect-socket-transport",
     "@walletconnect/types": "^1.8.0",
     "bowser": "2.11.0",
     "buffer": "^6.0.3",


### PR DESCRIPTION
# Overview

Temporarily patches v1 Wallet Connect with patched fork to allow installing in Vite while waiting on v2 migration

- https://github.com/awesome-algorand/walletconnect-socket-transport

# Related Issues

- resolves #101 