### PR TITLE
Upgrade `algosdk` to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@perawallet/connect",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@perawallet/connect",
-      "version": "1.3.4",
+      "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
         "@evanhahn/lottie-web-light": "5.8.1",
@@ -38,7 +38,7 @@
         "typescript": "^4.6.3"
       },
       "peerDependencies": {
-        "algosdk": "^2.1.0"
+        "algosdk": "^3.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1006,23 +1006,22 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/algo-msgpack-with-bigint": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/algo-msgpack-with-bigint/-/algo-msgpack-with-bigint-2.1.1.tgz",
-      "integrity": "sha512-F1tGh056XczEaEAqu7s+hlZUDWwOBT70Eq0lfMpBP2YguSQVyxRbprLq5rELXKQOyOaixTWYhMeMQMzP0U5FoQ==",
+    "node_modules/algorand-msgpack": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/algorand-msgpack/-/algorand-msgpack-1.1.0.tgz",
+      "integrity": "sha512-08k7pBQnkaUB5p+jL7f1TRaUIlTSDE0cesFu1mD7llLao+1cAhtvvZmGE3OnisTd0xOn118QMw74SRqddqaYvw==",
       "peer": true,
       "engines": {
-        "node": ">= 10"
+        "node": ">= 14"
       }
     },
     "node_modules/algosdk": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-2.9.0.tgz",
-      "integrity": "sha512-o0n0nLMbTX6SFQdMUk2/2sy50jmEmZk5OTPYSh2aAeP8DUPxrhjMPfwGsYNvaO+qk75MixC2eWpfA9vygCQ/Mg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-3.0.0.tgz",
+      "integrity": "sha512-PIKZ/YvbBpCudduug4KSH1CY/pTotI7/ccbUIbXKtcI9Onevl+57E+K5X4ow4gsCdysZ8zVvSLdxuCcXvsmPOw==",
       "peer": true,
       "dependencies": {
-        "algo-msgpack-with-bigint": "^2.1.1",
-        "buffer": "^6.0.3",
+        "algorand-msgpack": "^1.1.0",
         "hi-base32": "^0.5.1",
         "js-sha256": "^0.9.0",
         "js-sha3": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "version": "1.3.5",
+  "version": "1.4.0",
   "name": "@perawallet/connect",
   "description": "JavaScript SDK for integrating Pera Wallet to web applications.",
-  "main": "dist/index.js",
+  "module": "dist/index.js",
   "scripts": {
     "dev": "./node_modules/.bin/rollup -c -w",
     "build": "npm run eslint && ./node_modules/.bin/rollup -c",
@@ -43,7 +43,7 @@
     "qr-code-styling": "1.6.0-rc.1"
   },
   "peerDependencies": {
-    "algosdk": "^2.1.0"
+    "algosdk": "^3.0.0"
   },
   "types": "./dist/index.d.ts",
   "repository": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,7 +15,7 @@ export default [
     },
     output: {
       dir: "dist",
-      format: "cjs",
+      format: "esm",
       name: "PeraConnect",
       globals: {
         "@walletconnect/client": "WalletConnect",
@@ -32,7 +32,6 @@ export default [
       "@evanhahn/lottie-web-light",
       "bowser",
       "qr-code-styling",
-      "bufferutil",
       "utf-8-validate"
     ],
     plugins: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
-if (typeof window !== "undefined") {
-  // Pollyfill for Buffer
-  (window as any).global = window;
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  window.Buffer = window.Buffer || require("buffer").Buffer;
+(async () => {
+  if (typeof window !== "undefined") {
+    // Pollyfill for Buffer
+    (window as any).global = window;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    window.Buffer = window.Buffer || (await import('buffer')).Buffer;
 
-  import("./App");
-}
+    import("./App");
+  }
+})();
 
 import PeraWalletConnect from "./PeraWalletConnect";
 import {closePeraWalletSignTxnToast} from "./modal/peraWalletConnectModalUtils";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,14 @@
-(async () => {
-  if (typeof window !== "undefined") {
-    // Pollyfill for Buffer
-    (window as any).global = window;
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    window.Buffer = window.Buffer || (await import('buffer')).Buffer;
+import {Buffer} from 'buffer';
 
-    import("./App");
-  }
-})();
+if (typeof window !== "undefined") {
+  // Pollyfill for Buffer
+  (window as any).global = window;
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  window.Buffer = window.Buffer || Buffer;
+
+  import("./App");
+}
+
 
 import PeraWalletConnect from "./PeraWalletConnect";
 import {closePeraWalletSignTxnToast} from "./modal/peraWalletConnectModalUtils";


### PR DESCRIPTION
`algosdk` v3 has some breaking changes. This is the migration guide: https://github.com/algorand/js-algorand-sdk/blob/develop/v2_TO_v3_MIGRATION_GUIDE.md

Related issue: https://github.com/perawallet/connect/issues/170