### PR TITLE
perf(connect): eagerly prefetch and continuously reprime config promises

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@perawallet/connect",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@perawallet/connect",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "ISC",
       "dependencies": {
         "@evanhahn/lottie-web-light": "5.8.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.1",
+  "version": "1.5.2",
   "name": "@perawallet/connect",
   "description": "JavaScript SDK for integrating Pera Wallet to web applications.",
   "type": "module",

--- a/src/PeraWalletConnect.ts
+++ b/src/PeraWalletConnect.ts
@@ -87,6 +87,8 @@ class PeraWalletConnect {
   compactMode?: boolean;
   singleAccount?: boolean;
   private algodClients: Map<NetworkToggle, AlgodManager>;
+  private _configPromise: ReturnType<typeof getPeraConnectConfig> | null = null;
+  private _webviewCheckPromise: Promise<boolean> | null = null;
 
   constructor(options?: PeraWalletConnectOptions) {
     this.bridge = options?.bridge || "";
@@ -102,6 +104,11 @@ class PeraWalletConnect {
     this.compactMode = options?.compactMode || false;
     this.singleAccount = options?.singleAccount || false;
     this.algodClients = new Map();
+
+    // Eagerly start the two blocking operations so they resolve
+    // before the user taps Connect — avoids delay on iOS Safari.
+    this._configPromise = getPeraConnectConfig();
+    this._webviewCheckPromise = this.checkIsInWebview();
   }
 
   get platform() {
@@ -157,9 +164,13 @@ class PeraWalletConnect {
           shouldDisplayNewBadge,
           shouldUseSound,
           promoteMobile
-        } = await getPeraConnectConfig();
+        } = await (this._configPromise ?? getPeraConnectConfig());
 
-        this.isInWebview = await this.checkIsInWebview();
+        // Re-prime for next connect() call so it also benefits from prefetching
+        this._configPromise = getPeraConnectConfig();
+
+        this.isInWebview = await (this._webviewCheckPromise ?? this.checkIsInWebview());
+        this._webviewCheckPromise = this.checkIsInWebview();
 
         const onWebWalletConnect = runWebConnectFlow({
           resolve,


### PR DESCRIPTION


## Description
- Fix slow connect modal open times by eagerly prefetching and continuously repriming the blocking network calls that were happening synchronously during `connect()`

## Related Issues
- Closes https://algorandfoundation.atlassian.net/browse/PERA-3801

## Checklist
- [x] Have you tested your changes locally?
- [x] Have you reviewed the code for any potential issues?
- [ ] Have you documented any necessary changes in the project's documentation?
- [ ] Have you added any necessary tests for your changes?
- [ ] Have you updated any relevant dependencies?
