### PR TITLE
fix: ensure arc60 data is always base64 encoded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.0-beta.5",
+  "version": "1.6.0-beta.6",
   "name": "@perawallet/connect",
   "description": "JavaScript SDK for integrating Pera Wallet to web applications",
   "type": "module",

--- a/src/PeraWalletConnect.ts
+++ b/src/PeraWalletConnect.ts
@@ -675,7 +675,9 @@ class PeraWalletConnect {
       throw new Error("PeraWalletConnect was not initialized correctly.");
     }
 
-    const dataBase64 = Buffer.from(payload.data).toString("base64");
+    const dataBase64 = Buffer.isEncoding(metadata.encoding)
+      ? Buffer.from(payload.data, metadata.encoding).toString("base64")
+      : payload.data;
 
     const wireParams: Record<string, unknown> = {
       data: dataBase64,

--- a/src/transport/MobileTransport.ts
+++ b/src/transport/MobileTransport.ts
@@ -157,10 +157,10 @@ export class MobileTransport implements WalletTransport {
       throw new Error("PeraWalletConnect was not initialized correctly.");
     }
 
-    const dataBase64 =
-      metadata.encoding === "base64"
-        ? Buffer.from(payload.data, metadata.encoding).toString("base64")
-        : payload.data;
+    const dataBase64 = Buffer.isEncoding(metadata.encoding)
+      ? Buffer.from(payload.data, metadata.encoding).toString("base64")
+      : payload.data;
+
     const wireParams: Record<string, unknown> = {
       data: dataBase64,
       signer: algosdk.encodeAddress(payload.signer),

--- a/src/transport/extension/ExtensionTransport.ts
+++ b/src/transport/extension/ExtensionTransport.ts
@@ -135,10 +135,9 @@ export class ExtensionTransport implements WalletTransport {
       );
     }
 
-    const dataBase64 =
-      metadata.encoding === "base64"
-        ? Buffer.from(payload.data, metadata.encoding).toString("base64")
-        : payload.data;
+    const dataBase64 = Buffer.isEncoding(metadata.encoding)
+      ? Buffer.from(payload.data, metadata.encoding).toString("base64")
+      : payload.data;
 
     const wireParams: Record<string, unknown> = {
       data: dataBase64,


### PR DESCRIPTION
# Pull Request Template

## Description
- Fixing a bug where arc60 data is double base64 encoded.

## Checklist
- [ X ] Have you tested your changes locally?
- [ X ] Have you reviewed the code for any potential issues?
- [ X ] Have you documented any necessary changes in the project's documentation?
- [ X ] Have you added any necessary tests for your changes?
- [ X ] Have you updated any relevant dependencies?

## Additional Notes
- The build throws a warning `warning  Async method 'signArc60Data' has a complexity of 21. Maximum allowed is 20`. If that is unacceptable, it will need to be refactored.
