### PR TITLE
refactor: use new transports correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.0-beta.5",
+  "version": "1.6.0-beta.6",
   "name": "@perawallet/connect",
   "description": "JavaScript SDK for integrating Pera Wallet to web applications",
   "type": "module",

--- a/src/PeraWalletConnect.ts
+++ b/src/PeraWalletConnect.ts
@@ -6,12 +6,8 @@ import {sign_detached_verify} from "tweetnacl-ts";
 import PeraWalletConnectError from "./util/PeraWalletConnectError";
 import {
   openPeraWalletConnectModal,
-  openPeraWalletRedirectModal,
   removeModalWrapperFromDOM,
   PERA_WALLET_CONNECT_MODAL_ID,
-  PERA_WALLET_REDIRECT_MODAL_ID,
-  openPeraWalletSignTxnToast,
-  PERA_WALLET_SIGN_TXN_TOAST_ID,
   PeraWalletModalConfig,
   setupPeraWalletConnectModalCloseListener
 } from "./modal/peraWalletConnectModalUtils";
@@ -31,11 +27,7 @@ import {
   SignerTransaction,
   SignMetadata
 } from "./util/model/peraWalletModels";
-import {
-  base64ToUint8Array,
-  composeTransaction,
-  formatJsonRpcRequest
-} from "./util/transaction/transactionUtils";
+import {composeTransaction} from "./util/transaction/transactionUtils";
 import {isMobile} from "./util/device/deviceUtils";
 import {AlgorandChainIDs} from "./util/peraWalletTypes";
 import {runWebConnectFlow} from "./util/connect/connectFlow";
@@ -437,9 +429,11 @@ class PeraWalletConnect {
   ): Promise<boolean> {
     try {
       const {publicKey} = algosdk.decodeAddress(signerAddress);
-      const dataHash = new Uint8Array(await crypto.subtle.digest("SHA-256", data));
+      const dataHash = new Uint8Array(
+        await crypto.subtle.digest("SHA-256", Buffer.from(data))
+      );
       const authHash = new Uint8Array(
-        await crypto.subtle.digest("SHA-256", authenticatorData)
+        await crypto.subtle.digest("SHA-256", Buffer.from(authenticatorData))
       );
       const toBeVerified = concatArrays(dataHash, authHash);
 
@@ -485,23 +479,42 @@ class PeraWalletConnect {
     }
   }
 
+  private getTransport() {
+    if (this.platform === "extension") {
+      return this.extensionTransport;
+    }
+
+    if (this.platform === "web") {
+      return new WebTransport({
+        getWebWalletURL: async () => {
+          const config = await getPeraConnectConfig();
+
+          return config.webWalletURL;
+        }
+      });
+    }
+
+    if (!this.connector || !this.connector.sendCustomRequest) {
+      throw new Error("PeraWalletConnect was not initialized correctly.");
+    }
+
+    return new MobileTransport({
+      connector: this.connector as any,
+      shouldShowSignTxnToast: this.shouldShowSignTxnToast,
+      isInWebview: this.isInWebview,
+      getSilent: async () => {
+        const {silent} = await getPeraConnectConfig();
+
+        return silent;
+      }
+    });
+  }
+
   async signTransaction(
     txGroups: SignerTransaction[][],
     signerAddress?: string
   ): Promise<Uint8Array[]> {
-    if (this.platform === "mobile") {
-      if (isMobile() && !this.isInWebview) {
-        // This is to automatically open the wallet app when trying to sign with it.
-        openPeraWalletRedirectModal();
-      } else if (!isMobile() && this.shouldShowSignTxnToast) {
-        // This is to inform user go the wallet app when trying to sign with it.
-        openPeraWalletSignTxnToast();
-      }
-
-      if (!this.connector) {
-        throw new Error("PeraWalletConnect was not initialized correctly.");
-      }
-    }
+    const transport = this.getTransport();
 
     // Prepare transactions to be sent to wallet
     const signTxnRequestParams = txGroups.flatMap((txGroup) =>
@@ -510,24 +523,9 @@ class PeraWalletConnect {
       )
     );
 
-    if (this.platform === "web") {
-      const {webWalletURL} = await getPeraConnectConfig();
+    const result = await transport.signTransaction(signTxnRequestParams);
 
-      return new WebTransport({
-        getWebWalletURL: () => Promise.resolve(webWalletURL)
-      }).signTransaction(signTxnRequestParams);
-    }
-
-    if (this.platform === "extension") {
-      return this.extensionTransport.signTransaction(signTxnRequestParams);
-    }
-
-    return new MobileTransport({
-      connector: this.connector as any,
-      shouldShowSignTxnToast: this.shouldShowSignTxnToast,
-      isInWebview: this.isInWebview,
-      getSilent: async () => (await getPeraConnectConfig()).silent
-    }).signTransaction(signTxnRequestParams);
+    return result;
   }
 
   async signData(
@@ -538,39 +536,9 @@ class PeraWalletConnect {
     // eslint-disable-next-line no-magic-numbers
     const chainId = this.chainId || 4160;
 
-    if (this.platform === "mobile") {
-      if (isMobile() && !this.isInWebview) {
-        // This is to automatically open the wallet app when trying to sign with it.
-        openPeraWalletRedirectModal();
-      } else if (!isMobile() && this.shouldShowSignTxnToast) {
-        // This is to inform user go the wallet app when trying to sign with it.
-        openPeraWalletSignTxnToast();
-      }
+    const transport = this.getTransport();
 
-      if (!this.connector) {
-        throw new Error("PeraWalletConnect was not initialized correctly.");
-      }
-    }
-
-    let signatures: Uint8Array[];
-
-    if (this.platform === "extension") {
-      signatures = await this.extensionTransport.signData(data, signer, chainId);
-    } else if (this.platform === "web") {
-      const {webWalletURL} = await getPeraConnectConfig();
-
-      signatures = await new WebTransport({
-        getWebWalletURL: () => Promise.resolve(webWalletURL)
-      }).signData(data, signer, chainId);
-    } else {
-      // Pera Mobile Wallet flow
-      signatures = await new MobileTransport({
-        connector: this.connector as any,
-        shouldShowSignTxnToast: this.shouldShowSignTxnToast,
-        isInWebview: this.isInWebview,
-        getSilent: async () => (await getPeraConnectConfig()).silent
-      }).signData(data, signer, chainId);
-    }
+    const signatures: Uint8Array[] = await transport.signData(data, signer, chainId);
 
     // Verify signatures if validateSignature is true
     if (verifySignature) {
@@ -644,119 +612,35 @@ class PeraWalletConnect {
 
     this.assertArc60DomainMatchesOrigin(payload.domain);
 
-    if (this.platform === "extension") {
-      const response = await this.extensionTransport.signArc60Data(payload, metadata);
+    const transport = this.getTransport();
+    const response = await transport.signArc60Data(payload, metadata);
+    const effectiveSigner = algosdk.encodeAddress(payload.signer);
 
-      if (verifySignature) {
-        const ok = await this.verifyArc60Signature(
-          Buffer.from(payload.data, "base64"),
-          payload.authenticatorData,
-          response.signature,
-          algosdk.encodeAddress(payload.signer)
-        );
-
-        if (!ok) {
-          throw new PeraWalletConnectError(
-            {type: "SIGN_DATA_VERIFICATION_FAILED"},
-            "ARC-60 signature verification failed"
-          );
-        }
-      }
-
-      return response;
-    }
-
-    if (isMobile() && !this.isInWebview) {
-      // This is to automatically open the wallet app when trying to sign with it.
-      openPeraWalletRedirectModal();
-    }
-
-    if (!this.connector) {
-      throw new Error("PeraWalletConnect was not initialized correctly.");
-    }
-
-    const dataBase64 = Buffer.from(payload.data).toString("base64");
-
-    const wireParams: Record<string, unknown> = {
-      data: dataBase64,
-      signer: algosdk.encodeAddress(payload.signer),
-      domain: payload.domain,
-      authenticatorData: Buffer.from(payload.authenticatorData).toString("base64"),
-      metadata
-    };
-
-    if (payload.requestId !== undefined) wireParams.requestId = payload.requestId;
-    if (payload.hdPath !== undefined) wireParams.hdPath = payload.hdPath;
-
-    const request = formatJsonRpcRequest("algo_signData", wireParams);
-
-    try {
-      const {silent} = await getPeraConnectConfig();
-
-      // ARC-60 requires `params` to be a single object (not an array) — that
-      // is how the mobile wallet differentiates ARC-60 from legacy
-      // arbitrary-data requests. WalletConnect v1's request type insists on
-      // `params: any[]`, so we cast to bypass that constraint.
-      const response = await this.connector.sendCustomRequest(request as any, {
-        forcePushNotification: !silent
-      });
-
-      // Mobile returns the signature wrapped in an array.
-      const responseArray = Array.isArray(response) ? response : [response];
-      const first = responseArray.filter(Boolean)[0];
-
-      if (!first) {
-        throw new Error("No signature returned from wallet.");
-      }
-
-      const signature =
-        typeof first === "string"
-          ? base64ToUint8Array(first)
-          : Uint8Array.from(first as number[]);
-      const effectiveSigner = algosdk.encodeAddress(payload.signer);
-
-      if (verifySignature) {
-        // ARC-60 signatures are always produced by the requested account's
-        // own key — the wallet does not follow rekeys for off-chain data —
-        // so verify against the signer address's pubkey, not its auth addr.
-        const ok = await this.verifyArc60Signature(
-          Buffer.from(payload.data, "base64"),
-          payload.authenticatorData,
-          signature,
-          effectiveSigner
-        );
-
-        if (!ok) {
-          throw new PeraWalletConnectError(
-            {type: "SIGN_DATA_VERIFICATION_FAILED"},
-            "ARC-60 signature verification failed"
-          );
-        }
-      }
-
-      return {
-        data: dataBase64,
-        signer: algosdk.decodeAddress(effectiveSigner).publicKey,
-        domain: payload.domain,
-        authenticatorData: payload.authenticatorData,
-        ...(payload.requestId !== undefined && {requestId: payload.requestId}),
-        ...(payload.hdPath !== undefined && {hdPath: payload.hdPath}),
-        signature
-      };
-    } catch (error) {
-      return Promise.reject(
-        new PeraWalletConnectError(
-          {
-            type: "SIGN_TRANSACTIONS",
-            detail: error
-          },
-          (error as Error)?.message || "Failed to sign ARC-60 data"
-        )
+    if (verifySignature) {
+      const ok = await this.verifyArc60Signature(
+        Buffer.from(payload.data, "base64"),
+        payload.authenticatorData,
+        response.signature,
+        effectiveSigner
       );
-    } finally {
-      removeModalWrapperFromDOM(PERA_WALLET_REDIRECT_MODAL_ID);
-      removeModalWrapperFromDOM(PERA_WALLET_SIGN_TXN_TOAST_ID);
+
+      if (!ok) {
+        throw new PeraWalletConnectError(
+          {type: "SIGN_DATA_VERIFICATION_FAILED"},
+          "ARC-60 signature verification failed"
+        );
+      }
     }
+
+    return {
+      data: payload.data,
+      signer: algosdk.decodeAddress(effectiveSigner).publicKey,
+      domain: payload.domain,
+      authenticatorData: payload.authenticatorData,
+      ...(payload.requestId !== undefined && {requestId: payload.requestId}),
+      ...(payload.hdPath !== undefined && {hdPath: payload.hdPath}),
+      signature: response.signature
+    };
   }
 }
 

--- a/src/__tests__/PeraWalletConnect.orchestration.test.ts
+++ b/src/__tests__/PeraWalletConnect.orchestration.test.ts
@@ -1,4 +1,5 @@
 import {describe, it, expect, vi, afterEach} from "vitest";
+import algosdk from "algosdk";
 
 import PeraWalletConnect from "../PeraWalletConnect";
 import {ScopeType, SignMetadata} from "../util/model/peraWalletModels";
@@ -69,7 +70,9 @@ describe("PeraWalletConnect orchestration", () => {
     function makeArc60Payload(domain: string) {
       return {
         data: Buffer.from(new Uint8Array([1, 2])).toString("base64"),
-        signer: Buffer.from("SIGNER_ADDRESS"),
+        signer: algosdk.decodeAddress(
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ"
+        ).publicKey,
         domain,
         authenticatorData: new Uint8Array(37)
       };
@@ -107,7 +110,10 @@ describe("PeraWalletConnect orchestration", () => {
         .spyOn((pera as any).extensionTransport, "signArc60Data")
         .mockResolvedValue(response);
 
-      await expect(pera.signArc60Data(payload, AUTH_METADATA)).resolves.toBe(response);
+      await expect(pera.signArc60Data(payload, AUTH_METADATA)).resolves.toEqual({
+        ...payload,
+        signature: response.signature
+      });
       expect(spy).toHaveBeenCalledWith(payload, AUTH_METADATA);
     });
   });

--- a/src/transport/MobileTransport.ts
+++ b/src/transport/MobileTransport.ts
@@ -17,13 +17,16 @@ import {
 import {
   removeModalWrapperFromDOM,
   PERA_WALLET_REDIRECT_MODAL_ID,
-  PERA_WALLET_SIGN_TXN_TOAST_ID
+  PERA_WALLET_SIGN_TXN_TOAST_ID,
+  openPeraWalletRedirectModal,
+  openPeraWalletSignTxnToast
 } from "../modal/peraWalletConnectModalUtils";
+import {isMobile} from "../util/device/deviceUtils";
 
 // WalletConnect type is intentionally loose to avoid coupling the transport to
 // the connector's full type surface.
 type Connector = {
-  sendCustomRequest: (request: unknown, options?: unknown) => Promise<any>;
+  sendCustomRequest: (request: any, options?: any) => Promise<any>;
   accounts?: string[];
 } | null;
 
@@ -45,6 +48,14 @@ export class MobileTransport implements WalletTransport {
 
   constructor(deps: MobileTransportDeps) {
     this.deps = deps;
+
+    if (isMobile() && !deps.isInWebview) {
+      // This is to automatically open the wallet app when trying to sign with it.
+      openPeraWalletRedirectModal();
+    } else if (!isMobile() && deps.shouldShowSignTxnToast) {
+      // This is to inform user go the wallet app when trying to sign with it.
+      openPeraWalletSignTxnToast();
+    }
   }
 
   private get connector(): Connector {
@@ -88,9 +99,12 @@ export class MobileTransport implements WalletTransport {
 
     try {
       const silent = await this.deps.getSilent();
+
       const response = await this.connector.sendCustomRequest(formattedSignTxnRequest, {
         forcePushNotification: !silent
       });
+
+      console.log("sent request");
       const nonNullResponse = response.filter(Boolean) as (string | number[])[];
 
       return typeof nonNullResponse[0] === "string"
@@ -157,16 +171,21 @@ export class MobileTransport implements WalletTransport {
       throw new Error("PeraWalletConnect was not initialized correctly.");
     }
 
+    // force encoding to base64 for future proofing
     const dataBase64 =
-      metadata.encoding === "base64"
+      Buffer.isEncoding(metadata.encoding) && metadata.encoding !== "base64"
         ? Buffer.from(payload.data, metadata.encoding).toString("base64")
         : payload.data;
+
     const wireParams: Record<string, unknown> = {
       data: dataBase64,
       signer: algosdk.encodeAddress(payload.signer),
       domain: payload.domain,
       authenticatorData: Buffer.from(payload.authenticatorData).toString("base64"),
-      metadata
+      metadata: {
+        scope: metadata.scope,
+        encoding: "base64"
+      }
     };
 
     if (payload.requestId !== undefined) wireParams.requestId = payload.requestId;
@@ -182,11 +201,11 @@ export class MobileTransport implements WalletTransport {
       const responseArray = Array.isArray(response) ? response : [response];
       const first = responseArray.filter(Boolean)[0];
 
-      const effectiveSigner = algosdk.encodeAddress(payload.signer);
-
       if (!first) {
         throw new Error("No signature returned from wallet.");
       }
+
+      const effectiveSigner = algosdk.encodeAddress(payload.signer);
 
       const signature =
         typeof first === "string"

--- a/src/transport/extension/ExtensionTransport.ts
+++ b/src/transport/extension/ExtensionTransport.ts
@@ -136,16 +136,18 @@ export class ExtensionTransport implements WalletTransport {
     }
 
     const dataBase64 =
-      metadata.encoding === "base64"
+      Buffer.isEncoding(metadata.encoding) && metadata.encoding !== "base64"
         ? Buffer.from(payload.data, metadata.encoding).toString("base64")
         : payload.data;
-
     const wireParams: Record<string, unknown> = {
       data: dataBase64,
       signer: algosdk.encodeAddress(payload.signer),
       domain: payload.domain,
       authenticatorData: Buffer.from(payload.authenticatorData).toString("base64"),
-      metadata
+      metadata: {
+        scope: metadata.scope,
+        encoding: "base64"
+      }
     };
 
     if (payload.requestId !== undefined) wireParams.requestId = payload.requestId;

--- a/src/transport/extension/__tests__/ExtensionTransport.test.ts
+++ b/src/transport/extension/__tests__/ExtensionTransport.test.ts
@@ -62,7 +62,7 @@ describe("ExtensionTransport", () => {
 
     await transport.signArc60Data(
       {
-        data: new Uint8Array([1, 2]),
+        data: Buffer.from(new Uint8Array([1, 2])).toString("base64"),
         signer: signerPublicKey,
         domain,
         authenticatorData: new Uint8Array(37)

--- a/src/util/PeraWalletConnectError.ts
+++ b/src/util/PeraWalletConnectError.ts
@@ -18,6 +18,7 @@ interface PeraWalletConnectErrorData {
 
     // Sign
     | "SIGN_TRANSACTIONS"
+    | "SIGN_DATA"
     | "SIGN_TXN_CANCELLED"
     | "SIGN_TXN_NETWORK_MISMATCH"
     | "SIGN_DATA_CANCELLED"


### PR DESCRIPTION
# Pull Request Template

## Description
The arc60 path had not been converted to the new transport model yet, leading to lots of confusion around encodings.  This PR now correctly unifies the implementation to use the transports and cleans up the code as a result.  It also resolves finally the duplicate encoding and has been tested via the pera demo dapp with the current Pera 7 release.

## Related Issues
N/A

## Checklist
- [X] Have you tested your changes locally?
- [X] Have you reviewed the code for any potential issues?
- [ ] Have you documented any necessary changes in the project's documentation?
- [X] Have you added any necessary tests for your changes?
- [ ] Have you updated any relevant dependencies?

## Additional Notes
- Add any additional notes or comments that may be helpful for reviewers.
