### PR TITLE
fix: 1.6.0 stable release blockers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,14 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: pnpm
 
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint & test
+        run: pnpm run eslint && pnpm test
+
       - name: Build app
-        run: pnpm install --frozen-lockfile && pnpm run build:release
+        run: pnpm run build:release
 
       - name: Audit dependencies
         run: pnpm audit --prod --audit-level=moderate

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -51,7 +51,7 @@ export default [
       json(),
       sizes(),
       replace({
-        PERA_CONNECT_VERSION: `v${PeraConnectVersion} - BETA`,
+        PERA_CONNECT_VERSION: `v${PeraConnectVersion}`,
         preventAssignment: true
       }),
       nodePolyfills()

--- a/src/PeraWalletConnect.ts
+++ b/src/PeraWalletConnect.ts
@@ -43,7 +43,7 @@ import {isArc60OriginMismatch} from "./transport/extension/originBinding";
 import {MobileTransport} from "./transport/MobileTransport";
 import {WebTransport} from "./transport/WebTransport";
 import {ConnectOptions} from "./transport/WalletTransport";
-import {buildArc60SignDataResponse} from "./transport/arc60Wire";
+import {buildArc60SignDataResponse, decodeArc60SignedData} from "./transport/arc60Wire";
 import {Arc0027Client} from "./transport/extension/arc0027Client";
 
 interface PeraWalletConnectOptions {
@@ -618,7 +618,7 @@ class PeraWalletConnect {
 
     if (verifySignature) {
       const ok = await this.verifyArc60Signature(
-        Buffer.from(payload.data, "base64"),
+        decodeArc60SignedData(payload.data, metadata.encoding),
         payload.authenticatorData,
         response.signature,
         effectiveSigner

--- a/src/__tests__/PeraWalletConnect.signVerification.test.ts
+++ b/src/__tests__/PeraWalletConnect.signVerification.test.ts
@@ -1,5 +1,6 @@
 import {describe, it, expect, vi, afterEach} from "vitest";
 import algosdk from "algosdk";
+import {sign_detached} from "tweetnacl-ts";
 
 import PeraWalletConnect from "../PeraWalletConnect";
 import {ScopeType} from "../util/model/peraWalletModels";
@@ -215,4 +216,44 @@ describe("PeraWalletConnect.signArc60Data", () => {
     expect(withOptional.requestId).toBe("req-1");
     expect(withOptional.hdPath).toBe("m/44'/283'/0'/0/0");
   });
+
+  // Verification must decode `data` the same way the wire encoder does, using
+  // real crypto rather than a mocked verifier — mocking it is what let the
+  // encoding mismatch ship in the 1.6.0 betas.
+  describe.each(["base64", "hex", "utf8"])(
+    "verifies a genuine signature when encoding is %s",
+    (encoding) => {
+      it("accepts the wallet's signature over the decoded bytes", async () => {
+        saveWalletDetailsToStorage([account.addr.toString()], "pera-wallet");
+
+        const authenticatorData = new Uint8Array(37).fill(3);
+        const rawData = Buffer.from(`{"domain":"${window.location.origin}"}`, "utf8");
+        const payload = {
+          data: rawData.toString(encoding as BufferEncoding),
+          signer: algosdk.decodeAddress(account.addr.toString()).publicKey,
+          domain: window.location.origin,
+          authenticatorData
+        };
+
+        // Sign exactly what ARC-60 says the wallet signs.
+        const digest = async (bytes: Uint8Array) =>
+          new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
+        const toBeSigned = new Uint8Array([
+          ...(await digest(new Uint8Array(rawData))),
+          ...(await digest(authenticatorData))
+        ]);
+        const signature = sign_detached(toBeSigned, account.sk);
+
+        const pera = new PeraWalletConnect();
+
+        vi.spyOn(pera as any, "getTransport").mockReturnValue({
+          signArc60Data: vi.fn().mockResolvedValue({signature})
+        });
+
+        await expect(
+          pera.signArc60Data(payload, {scope: ScopeType.AUTH, encoding}, true)
+        ).resolves.toMatchObject({signature});
+      });
+    }
+  );
 });

--- a/src/transport/arc60Wire.ts
+++ b/src/transport/arc60Wire.ts
@@ -11,6 +11,24 @@ type Arc60WirePayload = Pick<
   "data" | "signer" | "domain" | "authenticatorData" | "requestId" | "hdPath"
 >;
 
+// Data is only re-encoded when the declared encoding is one Buffer understands
+// and isn't already base64; anything else goes out untouched and is labelled
+// base64 on the wire.
+function shouldConvertEncoding(encoding: SignMetadata["encoding"]) {
+  return Buffer.isEncoding(encoding) && encoding !== "base64";
+}
+
+/**
+ * The bytes the wallet actually signs. Mirrors `buildArc60WireParams` — keep
+ * the two in step, or local verification will hash different bytes than the
+ * wallet did.
+ */
+function decodeArc60SignedData(data: string, encoding: SignMetadata["encoding"]): Buffer {
+  return shouldConvertEncoding(encoding)
+    ? Buffer.from(data, encoding as BufferEncoding)
+    : Buffer.from(data, "base64");
+}
+
 // The extension and the mobile wallet both speak ARC-60 over `algo_signData`
 // with an object payload (rather than the array shape used for arbitrary-data
 // signing); this is the wire representation shared by both transports.
@@ -19,10 +37,9 @@ function buildArc60WireParams(
   metadata: SignMetadata
 ): Record<string, unknown> {
   // force encoding to base64 for future proofing
-  const dataBase64 =
-    Buffer.isEncoding(metadata.encoding) && metadata.encoding !== "base64"
-      ? Buffer.from(payload.data, metadata.encoding).toString("base64")
-      : payload.data;
+  const dataBase64 = shouldConvertEncoding(metadata.encoding)
+    ? Buffer.from(payload.data, metadata.encoding as BufferEncoding).toString("base64")
+    : payload.data;
 
   const wireParams: Record<string, unknown> = {
     data: dataBase64,
@@ -56,4 +73,4 @@ function buildArc60SignDataResponse(
   };
 }
 
-export {buildArc60WireParams, buildArc60SignDataResponse};
+export {buildArc60WireParams, buildArc60SignDataResponse, decodeArc60SignedData};


### PR DESCRIPTION


## Description
Blockers found reviewing #190–#201 before promoting 1.6.0-beta.7 to stable.

- **BETA label**: the version shown in the connect modal had `- BETA` hardcoded, so a stable build would read "v1.6.0 - BETA". Redundant since #192, prerelease versions now carry `-beta.N` themselves. Removed.
- **ARC-60 verification**: `signArc60Data(..., verifySignature: true)` always decoded `data` as base64 while the wire layer re-encodes hex/utf8, so valid signatures were rejected with `SIGN_DATA_VERIFICATION_FAILED` for any non-base64 encoding. Encode and decode now share one helper.
- **Release CI**: the tag-triggered workflow ran neither lint nor tests before publishing. Both now gate the publish.
