### PR TITLE
chore: bump version to 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.0-beta.7",
+  "version": "1.6.0",
   "name": "@perawallet/connect",
   "description": "JavaScript SDK for integrating Pera Wallet to web applications",
   "type": "module",


### PR DESCRIPTION
Version bump for the 1.6.0 stable release.

The `v1.6.0` tag has already been pushed and the package is published to npm under `latest`. This PR brings the version bump commit onto `main` (direct push was blocked by branch protection).

