### PR TITLE
fix: waking Pera at sign time disturbs the dApp tab in iOS Safari [PERA-4876]

### DIFF
--- a/src/modal/redirect/PeraWalletRedirectModal.ts
+++ b/src/modal/redirect/PeraWalletRedirectModal.ts
@@ -1,5 +1,6 @@
 import PeraRedirectIcon from "../../asset/icon/PeraRedirectIcon.svg";
 
+import {openDeepLinkInCurrentTab} from "../../util/dom/domUtils";
 import {generatePeraWalletAppDeepLink} from "../../util/peraWalletUtils";
 import {
   PERA_WALLET_REDIRECT_MODAL_ID,
@@ -43,9 +44,7 @@ peraWalletRedirectModalTemplate.innerHTML = `
 
         <a
           id="pera-wallet-redirect-modal-launch-pera-link"
-          class="pera-wallet-redirect-modal__launch-pera-wallet-button"
-          rel="noopener noreferrer"
-          target="_blank">
+          class="pera-wallet-redirect-modal__launch-pera-wallet-button">
           Launch Pera Wallet
         </a>
       </div>
@@ -81,21 +80,32 @@ export class PeraWalletRedirectModal extends HTMLElement {
       );
 
       launchPeraLink?.addEventListener("click", () => {
-        this.onClose();
-        window.open(generatePeraWalletAppDeepLink(), "_blank");
+        openDeepLinkInCurrentTab(generatePeraWalletAppDeepLink());
       });
     }
   }
 
   connectedCallback() {
-    const peraWalletDeepLink = window.open(generatePeraWalletAppDeepLink(), "_blank");
+    // Same-tab scheme navigation launches the wallet without unloading the
+    // page, so there is no synchronous success signal. The page going hidden
+    // is the launch confirmation; until then the modal stays as the
+    // "Can't Launch Pera" fallback.
+    document.addEventListener("visibilitychange", this.handleVisibilityChange);
 
-    if (peraWalletDeepLink && !peraWalletDeepLink.closed) {
-      this.onClose();
-    }
+    openDeepLinkInCurrentTab(generatePeraWalletAppDeepLink());
+  }
+
+  disconnectedCallback() {
+    document.removeEventListener("visibilitychange", this.handleVisibilityChange);
   }
 
   onClose() {
     removeModalWrapperFromDOM(PERA_WALLET_REDIRECT_MODAL_ID);
   }
+
+  private handleVisibilityChange = () => {
+    if (document.visibilityState === "hidden") {
+      this.onClose();
+    }
+  };
 }

--- a/src/modal/redirect/__tests__/PeraWalletRedirectModal.test.ts
+++ b/src/modal/redirect/__tests__/PeraWalletRedirectModal.test.ts
@@ -1,0 +1,116 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from "vitest";
+
+import {PeraWalletRedirectModal} from "../PeraWalletRedirectModal";
+import {openDeepLinkInCurrentTab} from "../../../util/dom/domUtils";
+import {
+  PERA_WALLET_REDIRECT_MODAL_ID,
+  openPeraWalletRedirectModal
+} from "../../peraWalletConnectModalUtils";
+
+vi.mock("../../../util/dom/domUtils", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  openDeepLinkInCurrentTab: vi.fn()
+}));
+
+vi.mock("../../../util/device/deviceUtils", () => ({
+  detectBrowser: () => "Chrome",
+  isAndroid: () => false,
+  isIOS: () => true,
+  isMobile: () => true
+}));
+
+const EXPECTED_DEEP_LINK = "perawallet-wc://?browser=Chrome";
+
+if (!window.customElements.get("pera-wallet-redirect-modal")) {
+  window.customElements.define("pera-wallet-redirect-modal", PeraWalletRedirectModal);
+}
+
+function renderRedirectModal() {
+  openPeraWalletRedirectModal();
+
+  return document.getElementById(PERA_WALLET_REDIRECT_MODAL_ID);
+}
+
+function setPageVisibility(state: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    value: state
+  });
+
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+describe("PeraWalletRedirectModal", () => {
+  let windowOpenSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    windowOpenSpy = vi.spyOn(window, "open").mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (document as any).visibilityState;
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it("wakes Pera by navigating the current tab, never by opening a new one", () => {
+    renderRedirectModal();
+
+    expect(openDeepLinkInCurrentTab).toHaveBeenCalledWith(EXPECTED_DEEP_LINK);
+    expect(windowOpenSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps the fallback modal on screen after triggering the launch", () => {
+    const wrapper = renderRedirectModal();
+
+    expect(wrapper).not.toBeNull();
+    expect(document.getElementById(PERA_WALLET_REDIRECT_MODAL_ID)).not.toBeNull();
+  });
+
+  it("closes once the page is hidden, meaning the app actually launched", () => {
+    renderRedirectModal();
+
+    setPageVisibility("hidden");
+
+    expect(document.getElementById(PERA_WALLET_REDIRECT_MODAL_ID)).toBeNull();
+  });
+
+  it("stays open while the page remains visible", () => {
+    renderRedirectModal();
+
+    setPageVisibility("visible");
+
+    expect(document.getElementById(PERA_WALLET_REDIRECT_MODAL_ID)).not.toBeNull();
+  });
+
+  it("launches via the current tab when the manual button is tapped", () => {
+    const wrapper = renderRedirectModal();
+
+    const launchLink = wrapper
+      ?.querySelector("pera-wallet-redirect-modal")
+      ?.shadowRoot?.getElementById("pera-wallet-redirect-modal-launch-pera-link");
+
+    vi.mocked(openDeepLinkInCurrentTab).mockClear();
+
+    launchLink?.click();
+
+    expect(openDeepLinkInCurrentTab).toHaveBeenCalledWith(EXPECTED_DEEP_LINK);
+    expect(windowOpenSpy).not.toHaveBeenCalled();
+    expect(document.getElementById(PERA_WALLET_REDIRECT_MODAL_ID)).not.toBeNull();
+  });
+
+  it("stops watching page visibility after it is removed from the DOM", () => {
+    const removeListenerSpy = vi.spyOn(document, "removeEventListener");
+
+    const wrapper = renderRedirectModal();
+
+    wrapper?.remove();
+
+    expect(removeListenerSpy).toHaveBeenCalledWith(
+      "visibilitychange",
+      expect.any(Function)
+    );
+  });
+});

--- a/src/util/dom/domUtils.ts
+++ b/src/util/dom/domUtils.ts
@@ -100,6 +100,16 @@ function waitForElementCreatedAtShadowDOM(
   });
 }
 
+/**
+ * Navigates the current tab to the given URL. For custom-scheme deep links this
+ * launches the app without unloading the page, unlike window.open(url, "_blank"),
+ * which spawns an extra browsing context (iOS Safari leaves the dApp on a blank
+ * or reloaded tab after returning from the wallet).
+ */
+function openDeepLinkInCurrentTab(url: string) {
+  window.location.href = url;
+}
+
 function waitForTabOpening(url: string): Promise<Window | null> {
   return new Promise((resolve, reject) => {
     try {
@@ -163,4 +173,10 @@ function waitForTabOpening(url: string): Promise<Window | null> {
   });
 }
 
-export {getMetaInfo, getFavicons, waitForElementCreatedAtShadowDOM, waitForTabOpening};
+export {
+  getMetaInfo,
+  getFavicons,
+  waitForElementCreatedAtShadowDOM,
+  openDeepLinkInCurrentTab,
+  waitForTabOpening
+};


### PR DESCRIPTION

## Problem
When a dApp on a mobile browser requests a signature, the redirect modal wakes Pera with `window.open(deepLink, "_blank")`. In iOS Safari this spawns an extra browsing context as a side effect, so after signing the user returns to a blank
or reloaded page and loses the dApp state they left (e.g. a pending swap result).

## Solution
- Wake the wallet with same-tab navigation (`window.location.href = deepLink`), which launches the app via the custom scheme without unloading the page.
- Same-tab navigation has no synchronous success signal, so the modal now closes on `visibilitychange`: the page going hidden confirms the app launched. If the app is not installed the page never hides and the modal stays as the "Can't Launch Pera" fallback with the manual launch and install links.
- The manual "Launch Pera Wallet" button had the same window.open problem and now navigates the same way.
