### PR TITLE
fix: signData errors are mislabeled as SIGN_TRANSACTIONS [PERA-4866]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.0-beta.7",
+  "version": "1.6.1-beta.0",
   "name": "@perawallet/connect",
   "description": "JavaScript SDK for integrating Pera Wallet to web applications",
   "type": "module",

--- a/src/transport/MobileTransport.ts
+++ b/src/transport/MobileTransport.ts
@@ -130,8 +130,8 @@ export class MobileTransport implements WalletTransport {
     } catch (error: any) {
       return Promise.reject(
         new PeraWalletConnectError(
-          {type: "SIGN_TRANSACTIONS", detail: error},
-          error.message || "Failed to sign transaction"
+          {type: "SIGN_DATA", detail: error},
+          error.message || "Failed to sign data"
         )
       );
     } finally {
@@ -171,7 +171,7 @@ export class MobileTransport implements WalletTransport {
     } catch (error) {
       return Promise.reject(
         new PeraWalletConnectError(
-          {type: "SIGN_TRANSACTIONS", detail: error},
+          {type: "SIGN_DATA", detail: error},
           (error as Error)?.message || "Failed to sign ARC-60 data"
         )
       );

--- a/src/transport/__tests__/MobileTransport.test.ts
+++ b/src/transport/__tests__/MobileTransport.test.ts
@@ -187,7 +187,7 @@ describe("MobileTransport", () => {
       ).rejects.toBeTruthy();
     });
 
-    it("wraps a connector rejection in a PeraWalletConnectError", async () => {
+    it("wraps a connector rejection in a SIGN_DATA PeraWalletConnectError", async () => {
       const connector = {
         sendCustomRequest: vi.fn().mockRejectedValue(new Error("denied"))
       };
@@ -200,7 +200,26 @@ describe("MobileTransport", () => {
           account.addr.toString(),
           4160
         )
-      ).rejects.toMatchObject({data: {type: "SIGN_TRANSACTIONS"}, message: "denied"});
+      ).rejects.toMatchObject({data: {type: "SIGN_DATA"}, message: "denied"});
+    });
+
+    it("falls back to a data-signing message when the rejection has none", async () => {
+      const connector = {
+        sendCustomRequest: vi.fn().mockRejectedValue(new Error())
+      };
+      const transport = makeTransport(connector);
+
+      await expect(
+        // eslint-disable-next-line no-magic-numbers
+        transport.signData(
+          [{data: new Uint8Array([1]), message: "m"}],
+          account.addr.toString(),
+          4160
+        )
+      ).rejects.toMatchObject({
+        data: {type: "SIGN_DATA"},
+        message: "Failed to sign data"
+      });
     });
   });
 
@@ -272,7 +291,7 @@ describe("MobileTransport", () => {
       expect(Array.from(response.signature)).toEqual([9, 9]);
     });
 
-    it("rejects when the wallet returns no signature", async () => {
+    it("rejects with SIGN_DATA when the wallet returns no signature", async () => {
       const connector = makeConnector([null]);
       const transport = makeTransport(connector);
 
@@ -281,7 +300,7 @@ describe("MobileTransport", () => {
           scope: ScopeType.AUTH,
           encoding: "base64"
         })
-      ).rejects.toMatchObject({data: {type: "SIGN_TRANSACTIONS"}});
+      ).rejects.toMatchObject({data: {type: "SIGN_DATA"}});
     });
   });
 });

--- a/src/transport/extension/ExtensionTransport.ts
+++ b/src/transport/extension/ExtensionTransport.ts
@@ -18,13 +18,18 @@ import {
   resetWalletDetailsFromStorage
 } from "../../util/storage/storageUtils";
 
-function mapError(error: unknown, context: "connect" | "sign"): PeraWalletConnectError {
+type MapErrorContext = "connect" | "sign-txn" | "sign-data";
+
+const CANCEL_ERROR_TYPES = {
+  "connect": "CONNECT_MODAL_CLOSED",
+  "sign-txn": "SIGN_TXN_CANCELLED",
+  "sign-data": "SIGN_DATA_CANCELLED"
+} as const;
+
+function mapError(error: unknown, context: MapErrorContext): PeraWalletConnectError {
   if (error instanceof Arc0027RequestError) {
     if (error.code === ARC0027_ERROR_CODES.MethodCanceledError) {
-      return new PeraWalletConnectError(
-        {type: context === "connect" ? "CONNECT_MODAL_CLOSED" : "SIGN_TXN_CANCELLED"},
-        error.message
-      );
+      return new PeraWalletConnectError({type: CANCEL_ERROR_TYPES[context]}, error.message);
     }
 
     if (error.code === ARC0027_ERROR_CODES.UnauthorizedSignerError) {
@@ -33,7 +38,7 @@ function mapError(error: unknown, context: "connect" | "sign"): PeraWalletConnec
   }
 
   return new PeraWalletConnectError(
-    {type: "SIGN_TRANSACTIONS", detail: error},
+    {type: context === "sign-data" ? "SIGN_DATA" : "SIGN_TRANSACTIONS", detail: error},
     (error as Error)?.message || "ARC-0027 request failed"
   );
 }
@@ -105,7 +110,7 @@ export class ExtensionTransport implements WalletTransport {
         .filter((value): value is string => typeof value === "string")
         .map(base64ToUint8Array);
     } catch (error) {
-      throw mapError(error, "sign");
+      throw mapError(error, "sign-txn");
     }
   }
 
@@ -142,7 +147,7 @@ export class ExtensionTransport implements WalletTransport {
 
       return buildArc60SignDataResponse(payload, signature);
     } catch (error) {
-      throw mapError(error, "sign");
+      throw mapError(error, "sign-data");
     }
   }
 }

--- a/src/transport/extension/__tests__/ExtensionTransport.test.ts
+++ b/src/transport/extension/__tests__/ExtensionTransport.test.ts
@@ -133,7 +133,7 @@ describe("ExtensionTransport", () => {
     expect(params.data).toBe(Buffer.from(raw).toString("base64"));
   });
 
-  it("signArc60Data() maps a request failure through mapError", async () => {
+  it("signArc60Data() maps a canceled request to SIGN_DATA_CANCELLED", async () => {
     const requestFn = vi
       .fn()
       .mockRejectedValue(
@@ -151,7 +151,24 @@ describe("ExtensionTransport", () => {
         },
         {scope: ScopeType.AUTH, encoding: "base64"}
       )
-    ).rejects.toMatchObject({data: {type: "SIGN_TXN_CANCELLED"}});
+    ).rejects.toMatchObject({data: {type: "SIGN_DATA_CANCELLED"}});
+  });
+
+  it("signArc60Data() maps an unrecognized error to a SIGN_DATA fallback", async () => {
+    const requestFn = vi.fn().mockRejectedValue(new Error("boom"));
+    const transport = new ExtensionTransport(makeClient(requestFn));
+
+    await expect(
+      transport.signArc60Data(
+        {
+          data: Buffer.from(new Uint8Array([1])).toString("base64"),
+          signer: algosdk.decodeAddress(account.addr.toString()).publicKey,
+          domain: window.location.origin,
+          authenticatorData: new Uint8Array(37)
+        },
+        {scope: ScopeType.AUTH, encoding: "base64"}
+      )
+    ).rejects.toMatchObject({data: {type: "SIGN_DATA"}, message: "boom"});
   });
 
   it("signArc60Data() rejects on origin mismatch before calling the extension", async () => {


### PR DESCRIPTION
## Problem

MobileTransport.signData and signArc60Data wrap rejections with `type: "SIGN_TRANSACTIONS"` (copied from `signTransaction`), and `ExtensionTransport.mapError` has the same fallback for ARC-60 data signing. dApps therefore log data-signing failures as transaction failures.

## Solution

- `MobileTransport.signData` / `signArc60Data` reject with `SIGN_DATA`; signData's fallback message becomes "Failed to sign data".
- `ExtensionTransport.mapError` now distinguishes sign-txn from sign-data: data-signing failures fall back to `SIGN_DATA` and cancels map to `SIGN_DATA_CANCELLED`, matching what the web wallet flow already emits.
- Transaction and connect paths keep their existing labels.
