### PR TITLE
chore: bump version to 1.6.1-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.0-beta.7",
+  "version": "1.6.1-beta.0",
   "name": "@perawallet/connect",
   "description": "JavaScript SDK for integrating Pera Wallet to web applications",
   "type": "module",


### PR DESCRIPTION
## Overall

Bumps the package version from `1.6.0-beta.7` to `1.6.1-beta.0` ahead of the 1.6.1 beta release that will include #204 and #205.

Note: this also brings `main`'s version field back in sync — the `v1.6.0` stable release was tagged on an unmerged bump branch, so `main` still carried `1.6.0-beta.7`.


